### PR TITLE
Use pagination for listing release assets

### DIFF
--- a/__tests__/ArtifactUploader.test.ts
+++ b/__tests__/ArtifactUploader.test.ts
@@ -194,22 +194,20 @@ describe('ArtifactUploader', () => {
     }
 
     function mockListWithAssets() {
-        listArtifactsMock.mockResolvedValue({
-            data: [
-                {
-                    name: "art1",
-                    id: 1
-                },
-                {
-                    name: "art2",
-                    id: 2
-                }
-            ]
-        })
+        listArtifactsMock.mockResolvedValue([
+            {
+                name: "art1",
+                id: 1
+            },
+            {
+                name: "art2",
+                id: 2
+            }
+        ])
     }
 
     function mockListWithoutAssets() {
-        listArtifactsMock.mockResolvedValue({data: []})
+        listArtifactsMock.mockResolvedValue([])
     }
 
     function mockUploadArtifact(status: number = 200, failures: number = 0) {

--- a/lib/ArtifactUploader.js
+++ b/lib/ArtifactUploader.js
@@ -70,8 +70,7 @@ class GithubArtifactUploader {
     }
     deleteUpdatedArtifacts(artifacts, releaseId) {
         return __awaiter(this, void 0, void 0, function* () {
-            const response = yield this.releases.listArtifactsForRelease(releaseId);
-            const releaseAssets = response.data;
+            const releaseAssets = yield this.releases.listArtifactsForRelease(releaseId);
             const assetByName = {};
             releaseAssets.forEach(asset => {
                 assetByName[asset.name] = asset;

--- a/lib/Releases.js
+++ b/lib/Releases.js
@@ -51,7 +51,7 @@ class GithubReleases {
     }
     listArtifactsForRelease(releaseId) {
         return __awaiter(this, void 0, void 0, function* () {
-            return this.git.repos.listReleaseAssets({
+            return this.git.paginate(this.git.repos.listReleaseAssets, {
                 owner: this.inputs.owner,
                 release_id: releaseId,
                 repo: this.inputs.repo

--- a/src/ArtifactUploader.ts
+++ b/src/ArtifactUploader.ts
@@ -52,8 +52,7 @@ export class GithubArtifactUploader implements ArtifactUploader {
     }
 
     private async deleteUpdatedArtifacts(artifacts: Artifact[], releaseId: number): Promise<void> {
-        const response = await this.releases.listArtifactsForRelease(releaseId)
-        const releaseAssets = response.data
+        const releaseAssets = await this.releases.listArtifactsForRelease(releaseId)
         const assetByName: Record<string, { id: number; name: string }> = {}
         releaseAssets.forEach(asset => {
             assetByName[asset.name] = asset

--- a/src/Releases.ts
+++ b/src/Releases.ts
@@ -6,7 +6,7 @@ import {Inputs} from "./Inputs";
 export type CreateReleaseResponse = RestEndpointMethodTypes["repos"]["createRelease"]["response"]
 export type ReleaseByTagResponse = RestEndpointMethodTypes["repos"]["getReleaseByTag"]["response"]
 export type ListReleasesResponse = RestEndpointMethodTypes["repos"]["listReleases"]["response"]
-export type ListReleaseAssetsResponse = RestEndpointMethodTypes["repos"]["listReleaseAssets"]["response"]
+export type ListReleaseAssetsResponseData = RestEndpointMethodTypes["repos"]["listReleaseAssets"]["response"]["data"]
 export type UpdateReleaseResponse = RestEndpointMethodTypes["repos"]["updateRelease"]["response"]
 export type UploadArtifactResponse = RestEndpointMethodTypes["repos"]["uploadReleaseAsset"]["response"]
 
@@ -25,7 +25,7 @@ export interface Releases {
 
     getByTag(tag: string): Promise<ReleaseByTagResponse>
 
-    listArtifactsForRelease(releaseId: number): Promise<ListReleaseAssetsResponse>
+    listArtifactsForRelease(releaseId: number): Promise<ListReleaseAssetsResponseData>
 
     listReleases(): Promise<ListReleasesResponse>
 
@@ -102,8 +102,8 @@ export class GithubReleases implements Releases {
 
     async listArtifactsForRelease(
         releaseId: number
-    ): Promise<ListReleaseAssetsResponse> {
-        return this.git.repos.listReleaseAssets({
+    ): Promise<ListReleaseAssetsResponseData> {
+        return this.git.paginate(this.git.repos.listReleaseAssets, {
             owner: this.inputs.owner,
             release_id: releaseId,
             repo: this.inputs.repo


### PR DESCRIPTION
The current `listArtifactsForRelease` method does not implement pagination and as such is limited to the default 30 results. As such, when updating a release with more than 30 assets, it will fail, as any assets over this number will not have been deleted prior to the reupload.

This PR changes the `listArtifactsForRelease` to use the `octokit.paginate` method, which handles the pagination. 

Please see https://github.com/ph1ll/release-action-example/actions/runs/752390024 for a comparison of v1.8.3 and this PR with debug logging.

Please let me know if you would like any changes, this was a quick fix and I am not familiar with GitHub actions.

Thanks for your work so far on this action.