### PR TITLE
Small improvements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Release Action
 
-This action will create a github release and optionally upload an artifact to it.
+This action will create a GitHub release and optionally upload an artifact to it.
 
 ## Action Inputs
-- **allowUpdates**: An optional flag which indicates if we should update a release if it already exists. Defaults to false.
+- **allowUpdates**: An optional flag which indicates if we should update a release if it already exists. Defaults to `false`.
 - **artifactErrorsFailBuild**: An optional flag which indicates if artifact read or upload errors should fail the build.  
 - **artifact**: An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs).
 - **artifacts**: An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs).
-- **artifactContentType**: The content type of the artifact. Defaults to raw.
+- **artifactContentType**: The content type of the artifact. Defaults to `raw`.
 - **body**: An optional body for the release.
 - **bodyFile**: An optional body file for the release. This should be the path to the file.
 - **commit**: An optional commit reference. This will be used to create the tag if it does not exist.
@@ -20,10 +20,10 @@ This action will create a github release and optionally upload an artifact to it
 - **omitNameDuringUpdate**: Indicates if the release name should be omitted during updates. The name will still be applied for newly created releases. This will preserve the existing name during updates.
 - **owner**: Optionally specify the owner of the repo where the release should be generated. Defaults to current repo's owner.
 - **prerelease**: Optionally marks this release as prerelease. Set to true to enable.
-- **replacesArtifacts**: Indicates if existing release artifacts should be replaced. Defaults to true.
+- **replacesArtifacts**: Indicates if existing release artifacts should be replaced. Defaults to `true`.
 - **repo**: Optionally specify the repo where the release should be generated. Defaults to current repo.
 - **tag**: An optional tag for the release. If this is omitted the git ref will be used (if it is a tag).
-- **token**: (**Required**) The Github token. Typically this will be `${{ secrets.GITHUB_TOKEN }}`.
+- **token**: (**Required**) The GitHub token. Typically this will be `${{ secrets.GITHUB_TOKEN }}`.
 
 ## Action Outputs
 - **id**: The identifier of the created release.
@@ -31,7 +31,7 @@ This action will create a github release and optionally upload an artifact to it
 - **upload_url**: The URL for uploading assets to the release.
 
 ## Example
-This example will create a release when tag is pushed:
+This example will create a release when a new tag is pushed:
 
 ```yml
 name: Releases
@@ -46,7 +46,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "release.tar.gz,foo/*.txt"
@@ -56,5 +56,5 @@ jobs:
 ```
 
 ## Notes
-- You must provide a tag either via the action input or the git ref (i.e push / create a tag). If you do not the action will fail.
-- If the tag of the release you are creating does not exist yet, you should set both the `tag` and `commit` action inputs. `commit` can point to a commit hash or a branch name (ex - `main`).
+- You must provide a tag either via the action input or the git ref (i.e push / create a tag). If you do not provide a tag the action will fail.
+- If the tag of the release you are creating does not yet exist, you should set both the `tag` and `commit` action inputs. `commit` can point to a commit hash or a branch name (ex - `main`).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This action will create a GitHub release and optionally upload an artifact to it
 - **upload_url**: The URL for uploading assets to the release.
 
 ## Example
-This example will create a release when a new tag is pushed:
+This example will create a release when a tag is pushed:
 
 ```yml
 name: Releases


### PR DESCRIPTION
## Changes:

- Capitalize proper noun GitHub
- Use mono-spaced font for some defaults
- Use actions/checkout@v2 in example as that is the latest stable release
- Improve grammar of some sentences

## Context:

I saw some small things that I could improve. 😉 