### PR TITLE
Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Changes:

- Use Dependabot to check for GitHub Action updates every working day (Monday-Friday)
- Use Dependabot to check for npm package updates every working day (Monday-Friday)

## Context:

I know you only wanted me to make a GitHub Action update config, but I wanted to see if I could nudge you into using Dependabot for your npm stuff as well. 😉

Right now the config is basically: "Turn Dependabot on, and rely on defaults".

There are some things we can tweak, like how often Dependabot should check for updates.
The "daily" interval will work on Mondays through Friday (bot takes the weekends off to party with other bots).
You can also check for updates on a weekly/monthly basis.

The default npm setup will use the `increase` version strategy, so it will bump the versions in your `package.json` to a higher range.

> For apps, the version requirements are increased, for example: npm, pip and Composer.

The benefit of using Dependabot for npm updates as well is that Dependabot will show you the changelogs of the package (if it can find them). That way you're in the loop more about upcoming changes, and what the new package will fix/break/etc. 😉 

If you're happy with your current npm setup (where you get security updates only), I can remove the npm config from this PR.

Fixes #66.

## Documentation:

- [GitHub docs, keeping your actions up-to-date with Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot)
- [GitHub docs, configuration options for dependency updates](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates)
- [GitHub docs, enabling and disabling version updates](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates)