### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ jobs:
       with:
         artifacts: "release.tar.gz,foo/*.txt"
         bodyFile: "body.md"
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.YOUR_GITHUB_TOKEN }}
 
 ```
 


### PR DESCRIPTION
 Failed to add secret. Secret names must not start with GITHUB_.