### PR TITLE
Readme: update checkout to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "release.tar.gz,foo/*.txt"


### PR DESCRIPTION
Update checkout to v3 which is the latest version and encourage people to use it when creating a release